### PR TITLE
chore: add aar-doc entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ types-PyYAML = "^6.0.12"
 isort = "^5.10.1"
 
 [tool.poetry.scripts]
-aar_doc = "aar_doc.cli:app"
 aar-doc = "aar_doc.cli:app"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ isort = "^5.10.1"
 
 [tool.poetry.scripts]
 aar_doc = "aar_doc.cli:app"
+aar-doc = "aar_doc.cli:app"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "^3.3.1"


### PR DESCRIPTION
This change resolves #75 by adding an `aar-doc` entrypoint to the `pyproject.toml`. After the installation the `aar-doc` command will be available as documented.