### PR TITLE
doc: Fix Ansible Galaxy role metadata URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ As noted above, the template _must_ start and end with the markers as comments, 
 
 `{{ content }}` will contain the rendered builtin output specific template content. For Markdown, see [templates/markdown.j2](./templates/markdown.j2).
 
-You will most likely want to skip using it in your own template however, and use the provided variables containing the [role metadata](https://galaxy.ansible.com/docs/contributing/creating_role.html#role-metadata) and [argument specs](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#specification-format) directly. `aar-doc` does not manipulate the values coming in from the YAML files in any way.
+You will most likely want to skip using it in your own template however, and use the provided variables containing the [role metadata](https://old-galaxy.ansible.com/docs/contributing/creating_role.html#role-metadata) and [argument specs](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#specification-format) directly. `aar-doc` does not manipulate the values coming in from the YAML files in any way.
 
 Template variables:
 


### PR DESCRIPTION
The location from the previous link was unknown and was redirected to the Ansible Galaxy starting page. It seems that they replaced their Ansible Galaxy and deprecated the old interface, breaking existing links.

closes #93 