### PR TITLE
proper indentation of sequence-of-mapping

### DIFF
--- a/aar_doc/defaults.py
+++ b/aar_doc/defaults.py
@@ -15,7 +15,7 @@ from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.scalarstring import LiteralScalarString, SingleQuotedScalarString
 
 yaml = YAML()
-yaml.indent(mapping=2, sequence=2, offset=2)
+yaml.indent(mapping=2, sequence=4, offset=2)
 yaml.encoding = "utf-8"
 yaml.allow_unicode = True
 

--- a/tests/fixtures/roles/generate_defaults/defaults/main.yml
+++ b/tests/fixtures/roles/generate_defaults/defaults/main.yml
@@ -31,6 +31,12 @@ generate_defaults_dict:
   value1: first value
   value2: second value
   value3: third value
+# A list-of-dict value
+generate_defaults_list_of_dict:
+  - value1: first value
+    value2: second value
+  - value3: third value
+    value4: fourth value
 # A string value that can be overwritten
 generate_defaults_overwrite: original value
 generate_defaults_no_description: foo

--- a/tests/fixtures/roles/generate_defaults/defaults/overwrite.yml
+++ b/tests/fixtures/roles/generate_defaults/defaults/overwrite.yml
@@ -31,6 +31,12 @@ generate_defaults_dict:
   value1: first value
   value2: second value
   value3: third value
+# A list-of-dict value
+generate_defaults_list_of_dict:
+  - value1: first value
+    value2: second value
+  - value3: third value
+    value4: fourth value
 # A string value that was overwritten
 generate_defaults_overwrite: overwritten value
 generate_defaults_no_description: foo

--- a/tests/fixtures/roles/generate_defaults/meta/argument_specs.yml
+++ b/tests/fixtures/roles/generate_defaults/meta/argument_specs.yml
@@ -59,6 +59,14 @@ argument_specs:
           value2: second value
           value3: third value
         description: A dictionary value
+      generate_defaults_list_of_dict:
+        type: list
+        default:
+          - value1: first value
+            value2: second value
+          - value3: third value
+            value4: fourth value
+        description: A list-of-dict value
       generate_defaults_overwrite:
         type: str
         default: original value


### PR DESCRIPTION
This fixes #120 by following the recommendation from `ruamel.yaml`s docs:

> **It is best to always have sequence >= offset + 2 but this is not enforced.** Depending on your structure, not following this advice **might lead to invalid output.**

-- https://yaml.dev/doc/ruamel.yaml/detail/#Indentation_of_block_sequences