### PR TITLE
fix(#123): minor formatting issues in readme markdown template

### DIFF
--- a/aar_doc/templates/markdown.j2
+++ b/aar_doc/templates/markdown.j2
@@ -29,10 +29,10 @@ Tags: {{ metadata.galaxy_info.galaxy_tags | join(', ') }}
 {{ argument_specs[entrypoint].description }}
 {% else %}
 {%- for line in argument_specs[entrypoint].description -%}
-{{ line }}
-{% endfor -%}
-{% endif -%}
-{% endif -%}
+{{ line }}  
+{% endfor %}
+{% endif %}
+{% endif %}
 
 {% if entrypoint_options[entrypoint] %}
 {%- set path, options=entrypoint_options[entrypoint][0] -%}


### PR DESCRIPTION
This PR fixes #123.

Before (as rendered on Ansible Galaxy):
![image](https://github.com/user-attachments/assets/6654bdcd-8aca-4ef8-8b1c-4736550abebe)

After:
![image](https://github.com/user-attachments/assets/3c933e43-d203-485c-997d-47d339d89d26)
