### PR TITLE
add basic handling of Ansible doc markup

### DIFF
--- a/aar_doc/templates/markdown.j2
+++ b/aar_doc/templates/markdown.j2
@@ -3,7 +3,7 @@
 {%- if "version" in galaxy_collection %}
 Version: {{ galaxy_collection.version }}
 {% endif %}
-{{ metadata.galaxy_info.description }}
+{{ metadata.galaxy_info.description | ansible_doc_markup }}
 {% if ("galaxy_tags" in metadata.galaxy_info) and (metadata.galaxy_info.galaxy_tags | length > 0) %}
 Tags: {{ metadata.galaxy_info.galaxy_tags | join(', ') }}
 {%- endif %}
@@ -22,14 +22,15 @@ Tags: {{ metadata.galaxy_info.galaxy_tags | join(', ') }}
 
 ### Entrypoint: {{ entrypoint }}
 
-{{ argument_specs[entrypoint].short_description }}
+{{ argument_specs[entrypoint].short_description | ansible_doc_markup }}
 
 {% if "description" in argument_specs[entrypoint] %}
 {%- if argument_specs[entrypoint].description is string -%}
-{{ argument_specs[entrypoint].description }}
+{{ argument_specs[entrypoint].description | ansible_doc_markup }}
 {% else %}
 {%- for line in argument_specs[entrypoint].description -%}
-{{ line }}
+{{ line | ansible_doc_markup }}
+
 {% endfor -%}
 {% endif -%}
 {% endif -%}
@@ -39,7 +40,7 @@ Tags: {{ metadata.galaxy_info.galaxy_tags | join(', ') }}
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 {%- for name, details in options.items() %}
-| {{ name }} | {{ details.display_description }} | {{ details.display_type }} | {{ details.display_required }} | {{ details.display_default }} |
+| {{ name }} | {{ details.display_description | ansible_doc_markup }} | {{ details.display_type }} | {{ details.display_required }} | {{ details.display_default }} |
 {%- endfor %}
 
 {% if entrypoint_options[entrypoint] | length > 1 -%}
@@ -49,7 +50,7 @@ Tags: {{ metadata.galaxy_info.galaxy_tags | join(', ') }}
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 {%- for name, details in options.items() %}
-| {{ name }} | {{ details.display_description }} | {{ details.display_type }} | {{ details.display_required }} | {{ details.display_default }} |
+| {{ name }} | {{ details.display_description | ansible_doc_markup }} | {{ details.display_type }} | {{ details.display_required }} | {{ details.display_default }} |
 {%- endfor %}
 
 {% endfor -%}

--- a/tests/fixtures/roles/markup/README.md
+++ b/tests/fixtures/roles/markup/README.md
@@ -1,0 +1,57 @@
+<!-- BEGIN_ANSIBLE_DOCS -->
+# Ansible Role: markup
+Test role with markup in descriptions
+
+
+## Requirements
+
+| Platform | Versions |
+| -------- | -------- |
+| Fedora | all |
+
+## Role Arguments
+
+
+
+### Entrypoint: main
+
+This summary contains **bold**, *italic* and `monospace` text as well as an [URL](https://github.com/telekom-mms/Automated-Ansible-Role-Documentation).
+
+This is an example of **bold** text.
+
+This is an example of *italic* text.
+
+This is an example of `monospace` text.
+
+This is an example of an [URL](https://github.com/telekom-mms/Automated-Ansible-Role-Documentation).
+
+|Option|Description|Type|Required|Default|
+|---|---|---|---|---|
+| myapp_int | The integer value. Defaults to `42`. For string, see `myapp_str`. | int | no | 42 |
+| myapp_str | The string value. No default value. For int, see `myapp_int`. | str | yes |  |
+
+
+
+## Dependencies
+None.
+
+## Example Playbook
+
+```
+- hosts: all
+  tasks:
+    - name: Importing role: markup
+      ansible.builtin.import_role:
+        name: markup
+      vars:
+        myapp_str: # required, type: str
+```
+
+## License
+
+MIT
+
+## Author and Project Information
+your name @ ansible-docs
+
+<!-- END_ANSIBLE_DOCS -->

--- a/tests/fixtures/roles/markup/meta/argument_specs.yml
+++ b/tests/fixtures/roles/markup/meta/argument_specs.yml
@@ -1,0 +1,26 @@
+---
+argument_specs:
+  main:
+    short_description: >-
+      This summary contains B(bold), I(italic) and C(monospace) text as well as an L(URL,https://github.com/telekom-mms/Automated-Ansible-Role-Documentation).
+    description:
+      - This is an example of B(bold) text.
+      - This is an example of I(italic) text.
+      - This is an example of C(monospace) text.
+      - This is an example of an L(URL,https://github.com/telekom-mms/Automated-Ansible-Role-Documentation).
+    options:
+      myapp_int:
+        type: "int"
+        required: false
+        default: 42
+        description:
+          - The integer value.
+          - Defaults to C(42).
+          - For string, see O(myapp_str).
+      myapp_str:
+        type: "str"
+        required: true
+        description:
+          - The string value.
+          - No default value.
+          - For int, see O(myapp_int).

--- a/tests/fixtures/roles/markup/meta/main.yml
+++ b/tests/fixtures/roles/markup/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: markup
+  author: your name
+  description: Test role with markup in descriptions
+  company: ansible-docs
+
+  license: MIT
+
+  min_ansible_version: "1.2"
+
+  platforms:
+    - name: Fedora
+      versions:
+        - all

--- a/tests/fixtures/roles/multiline/README.md
+++ b/tests/fixtures/roles/multiline/README.md
@@ -1,0 +1,53 @@
+<!-- BEGIN_ANSIBLE_DOCS -->
+# Ansible Role: multiline
+Test role with multiline descriptions
+
+
+## Requirements
+
+| Platform | Versions |
+| -------- | -------- |
+| Fedora | all |
+
+## Role Arguments
+
+
+
+### Entrypoint: main
+
+The main entry point for the multiline role.
+
+This is a role description
+
+that consists of multiple line
+
+|Option|Description|Type|Required|Default|
+|---|---|---|---|---|
+| myapp_int | The integer value. Defaults to 42. | int | no | 42 |
+| myapp_str | The string value. No default value. | str | yes |  |
+
+
+
+## Dependencies
+None.
+
+## Example Playbook
+
+```
+- hosts: all
+  tasks:
+    - name: Importing role: multiline
+      ansible.builtin.import_role:
+        name: multiline
+      vars:
+        myapp_str: # required, type: str
+```
+
+## License
+
+MIT
+
+## Author and Project Information
+your name @ ansible-docs
+
+<!-- END_ANSIBLE_DOCS -->

--- a/tests/fixtures/roles/multiline/meta/argument_specs.yml
+++ b/tests/fixtures/roles/multiline/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    short_description: The main entry point for the multiline role.
+    description:
+      - This is a role description
+      - that consists of multiple line
+    options:
+      myapp_int:
+        type: "int"
+        required: false
+        default: 42
+        description:
+          - The integer value.
+          - Defaults to 42.
+      myapp_str:
+        type: "str"
+        required: true
+        description:
+          - The string value.
+          - No default value.

--- a/tests/fixtures/roles/multiline/meta/main.yml
+++ b/tests/fixtures/roles/multiline/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: multiline
+  author: your name
+  description: Test role with multiline descriptions
+  company: ansible-docs
+
+  license: MIT
+
+  min_ansible_version: "1.2"
+
+  platforms:
+    - name: Fedora
+      versions:
+        - all

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -254,7 +254,7 @@ def test_output_template(tmp_path):
 
 
 def test_markdown(tmp_path):
-    roles = ["minimum", "extended", "multiple_entrypoints", "no_options"]
+    roles = ["minimum", "extended", "multiple_entrypoints", "no_options", "multiline", "markup"]
 
     for role_path in [ROLES_DIR / x for x in roles]:
         role = role_path.stem


### PR DESCRIPTION
This PR implements a simple Jinja filter for converting Ansible doc markup syntax to Markdown for inclusion in the README.

Before (as rendered by Ansible Galaxy):

![image](https://github.com/user-attachments/assets/4ee55334-14f9-4c5d-9e14-e75d8382887e)

After:

![image](https://github.com/user-attachments/assets/2239722a-8892-4519-b5a9-6af311bc9963)

Fixes #125 
Fixes #123 
Closes #124