### PR TITLE
fix: Support for "null" value in arguments_specs defaults

### DIFF
--- a/aar_doc/core.py
+++ b/aar_doc/core.py
@@ -242,7 +242,9 @@ def parse_options(ctx: typer.Context) -> dict:
                         )
 
                     elif display_type == "str":
-                        if not isinstance(default_value, str):
+                        if not (
+                            isinstance(default_value, str) or default_value is None
+                        ):
                             typer.echo(
                                 f"The default value of the argument {option} "
                                 f"is of type {type(default_value).__name__}, need str",

--- a/tests/fixtures/roles/extended/README.md
+++ b/tests/fixtures/roles/extended/README.md
@@ -33,6 +33,7 @@ This contains the various parameters one can give in argument_specs that do not 
 | choices-str | So many choices to make | str | no |  |
 | choices-int | So many choices to make | int | no |  |
 | default | This one has a default | str | no | long |
+| default_null | This one has null as a default | str | no | None |
 | required | This one is required | str | yes |  |
 | default_type | Type is str by default | str | no |  |
 
@@ -68,8 +69,11 @@ The list entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | list_int | A list of ints | list of 'int' | no | [1, 2, 3] |
+| list_int_null | A list of ints, null as a default | list of 'int' | no | None |
 | list_str | A list of strings | list of 'str' | no | ['foo', 'bar', 'baz'] |
+| list_str_null | A list of strings, null as a default | list of 'str' | no | None |
 | list_dict | A list of dicts | list of 'dict' | no | [{'dict': {'foo': 'bar'}}, {'dict': {'one': 1, 'two': 2}}] |
+| list_dict_null | A list of dicts, null as a default | list of 'dict' | no | None |
 
 
 
@@ -80,6 +84,7 @@ The dict entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | dict | A dictionary of keys and values | dict | no | {"dict": {"foo": "bar", "one": 1, "two": 2}} |
+| dict_null | A dictionary of keys and values, null as values | dict | no | {"dict": {"foo": null}} |
 
 
 
@@ -90,6 +95,7 @@ The dict-with-options entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | opts | A dictionary of keys and values | dict of 'opts' options | no |  |
+| opts_null | A dictionary of keys and values, null as a default | dict of 'opts_null' options | no | None |
 
 #### Options for dict-with-options > opts
 
@@ -100,6 +106,20 @@ The dict-with-options entry point for the extended role.
 | subopts | A sub-dictionary of keys and values | dict of 'subopts' options | no |  |
 
 #### Options for dict-with-options > opts > subopts
+
+|Option|Description|Type|Required|Default|
+|---|---|---|---|---|
+| str | A str value | str | no |  |
+
+#### Options for dict-with-options > opts_null
+
+|Option|Description|Type|Required|Default|
+|---|---|---|---|---|
+| int | An int value | int | no | 1 |
+| json | A JSON value | json | no | {"foo": "bar"} |
+| subopts | A sub-dictionary of keys and values | dict of 'subopts' options | no |  |
+
+#### Options for dict-with-options > opts_null > subopts
 
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
@@ -127,6 +147,7 @@ The int entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | int | An int value | int | no | 1 |
+| int_null | An int value, null as a default | int | no | None |
 
 
 
@@ -137,6 +158,7 @@ The float entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | float | A float value | float | no | 1.2 |
+| float_null | A float value, null as a default | float | no | None |
 
 
 
@@ -147,6 +169,7 @@ The path entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | path | A path value | path | no | /tmp/foo/bar |
+| path_null | A path value, null as a default | path | no | None |
 
 
 
@@ -157,7 +180,9 @@ The raw entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | raw_str | A raw str value | raw | no | raw |
+| raw_str_null | A raw str value, null as a default | raw | no | None |
 | raw_int | A raw int value | raw | no | 123 |
+| raw_int_null | A raw int value, null as a default | raw | no | None |
 
 
 
@@ -168,6 +193,7 @@ The jsonarg entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | jsonarg | A JSON value | jsonarg | no | {"foo": "bar"} |
+| jsonarg_null | A JSON value, null as a default | jsonarg | no | None |
 
 
 
@@ -178,6 +204,7 @@ The json entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | json | A JSON value | json | no | {"foo": "bar"} |
+| json_null | A JSON value, null as a default | json | no | None |
 
 
 
@@ -188,6 +215,7 @@ The bytes entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | bytes | A bytes value | bytes | no | 1.15GB |
+| bytes_null | A bytes value, null as a default | bytes | no | None |
 
 
 
@@ -198,6 +226,7 @@ The bits entry point for the extended role.
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | bytes | A bit value | bits | no | 1Mb |
+| bytes_null | A bit value, null as a default | bits | no | None |
 
 
 

--- a/tests/fixtures/roles/extended/meta/argument_specs.yml
+++ b/tests/fixtures/roles/extended/meta/argument_specs.yml
@@ -48,6 +48,10 @@ argument_specs:
         type: str
         description: This one has a default
         default: long
+      default_null:
+        type: str
+        description: This one has null as a default
+        default: null
       required:
         type: str
         required: true
@@ -65,6 +69,11 @@ argument_specs:
           - 2
           - 3
         description: A list of ints
+      list_int_null:
+        type: list
+        elements: int
+        default: null
+        description: A list of ints, null as a default
       list_str:
         type: list
         elements: str
@@ -73,6 +82,11 @@ argument_specs:
           - bar
           - baz
         description: A list of strings
+      list_str_null:
+        type: list
+        elements: str
+        default: null
+        description: A list of strings, null as a default
       list_dict:
         type: list
         elements: dict
@@ -83,6 +97,11 @@ argument_specs:
               one: 1
               two: 2
         description: A list of dicts
+      list_dict_null:
+        type: list
+        elements: dict
+        default: null
+        description: A list of dicts, null as a default
   dict:
     short_description: The dict entry point for the extended role.
     options:
@@ -94,6 +113,12 @@ argument_specs:
             one: 1
             two: 2
         description: A dictionary of keys and values
+      dict_null:
+        type: dict
+        default:
+          dict:
+            foo: null
+        description: A dictionary of keys and values, null as values
   dict-with-options:
     short_description: The dict-with-options entry point for the extended role.
     options:
@@ -117,6 +142,27 @@ argument_specs:
               str:
                 type: str
                 description: A str value
+      opts_null:
+        type: dict
+        description: A dictionary of keys and values, null as a default
+        options:
+          int:
+            type: int
+            default: 1
+            description: An int value
+          json:
+            type: json
+            default: >
+              {"foo": "bar"}
+            description: A JSON value
+          subopts:
+            type: dict
+            description: A sub-dictionary of keys and values
+            options:
+              str:
+                type: str
+                description: A str value
+        default: null
   bool:
     short_description: The bool entry point for the extended role.
     options:
@@ -143,6 +189,10 @@ argument_specs:
         type: int
         default: 1
         description: An int value
+      int_null:
+        type: int
+        default: null
+        description: An int value, null as a default
   float:
     short_description: The float entry point for the extended role.
     options:
@@ -150,6 +200,10 @@ argument_specs:
         type: float
         default: 1.2
         description: A float value
+      float_null:
+        type: float
+        default: null
+        description: A float value, null as a default
   path:
     short_description: The path entry point for the extended role.
     options:
@@ -157,6 +211,10 @@ argument_specs:
         type: path
         default: /tmp/foo/bar
         description: A path value
+      path_null:
+        type: path
+        default: null
+        description: A path value, null as a default
   raw:
     short_description: The raw entry point for the extended role.
     options:
@@ -164,10 +222,18 @@ argument_specs:
         type: raw
         default: raw
         description: A raw str value
+      raw_str_null:
+        type: raw
+        default: null
+        description: A raw str value, null as a default
       raw_int:
         type: raw
         default: 123
         description: A raw int value
+      raw_int_null:
+        type: raw
+        default: null
+        description: A raw int value, null as a default
   jsonarg:
     short_description: The jsonarg entry point for the extended role.
     options:
@@ -176,6 +242,10 @@ argument_specs:
         default: >
           {"foo": "bar"}
         description: A JSON value
+      jsonarg_null:
+        type: jsonarg
+        default: null
+        description: A JSON value, null as a default
   json:
     short_description: The json entry point for the extended role.
     options:
@@ -184,6 +254,10 @@ argument_specs:
         default: >
           {"foo": "bar"}
         description: A JSON value
+      json_null:
+        type: json
+        default: null
+        description: A JSON value, null as a default
   bytes:
     short_description: The bytes entry point for the extended role.
     options:
@@ -191,6 +265,10 @@ argument_specs:
         type: bytes
         default: 1.15GB
         description: A bytes value
+      bytes_null:
+        type: bytes
+        default: null
+        description: A bytes value, null as a default
   bits:
     short_description: The bits entry point for the extended role.
     options:
@@ -198,3 +276,7 @@ argument_specs:
         type: bits
         default: 1Mb
         description: A bit value
+      bytes_null:
+        type: bits
+        default: null
+        description: A bit value, null as a default


### PR DESCRIPTION
## Description
In some cases a user may have a `null` value as a default (like in terraform) and have various Jinja2/Ansible conditions based 
on the `null`/`!null` in the tasks and templated.

Currently `aar-doc` fails in cases like 
```yaml
argument_specs:
  main:
    short_description: The main entry point for the minimum role.
    options:
      myapp_str:
        type: "str"
        required: false
        default: null
        description: "The str value, defaulting to null."
```

PR adds handling `null` values in the defaults